### PR TITLE
Add linear regression chart with value input

### DIFF
--- a/app/src/main/java/com/example/composecollectwords/MainActivity.kt
+++ b/app/src/main/java/com/example/composecollectwords/MainActivity.kt
@@ -4,23 +4,18 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.text.input.rememberTextFieldState
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.Button
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextField
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
+import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import com.example.composecollectwords.ui.theme.ComposeCollectWordsTheme
 
 class MainActivity : ComponentActivity() {
@@ -30,45 +25,83 @@ class MainActivity : ComponentActivity() {
         setContent {
             ComposeCollectWordsTheme {
                 Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
-//                    Greeting(
-//                        name = "Android",
-//                        modifier = Modifier.padding(innerPadding)
-//                    )
-                    Text("Collect words", Modifier.padding(innerPadding), fontSize = 35.sp)
-
-                    SimpleOutlinedTextField()
+                    MainScreen(Modifier.padding(innerPadding))
                 }
-
             }
         }
     }
-
-
 }
 
 @Composable
-private fun SimpleOutlinedTextField() {
-    var text by remember { mutableStateOf("") }
+fun MainScreen(modifier: Modifier = Modifier) {
+    var input by remember { mutableStateOf("") }
+    var values by remember { mutableStateOf(listOf<Float>()) }
 
-    OutlinedTextField(
-        value = text,
-        onValueChange = { text = it },
-        label = { Text("Label") }
-    )
-
+    Column(modifier.padding(16.dp)) {
+        OutlinedTextField(
+            value = input,
+            onValueChange = { input = it },
+            label = { Text("Number") },
+            modifier = Modifier.fillMaxWidth()
+        )
+        Button(
+            onClick = {
+                input.toFloatOrNull()?.let {
+                    values = values + it
+                    input = ""
+                }
+            },
+            modifier = Modifier.padding(top = 8.dp)
+        ) {
+            Text("Insert value")
+        }
+        RegressionChart(values, Modifier.padding(top = 16.dp))
+    }
 }
-//@Composable
-//fun Greeting(name: String, modifier: Modifier = Modifier) {
-//    Text(
-//        text = "Hello $name!",
-//        modifier = modifier
-//    )
-//}
-//
-//@Preview(showBackground = true)
-//@Composable
-//fun GreetingPreview() {
-//    ComposeCollectWordsTheme {
-//        Greeting("Android")
-//    }
-//}
+
+@Composable
+fun RegressionChart(points: List<Float>, modifier: Modifier = Modifier) {
+    if (points.isEmpty()) return
+
+    val xs = points.indices.map { it.toDouble() }
+    val ys = points.map { it.toDouble() }
+    val xMean = xs.average()
+    val yMean = ys.average()
+    val numerator = xs.zip(ys).sumOf { (x, y) -> (x - xMean) * (y - yMean) }
+    val denominator = xs.sumOf { (x - xMean) * (x - xMean) }
+    val slope = if (denominator == 0.0) 0.0 else numerator / denominator
+    val intercept = yMean - slope * xMean
+    val y0 = intercept
+    val yN = slope * xs.last() + intercept
+
+    val allY = ys + listOf(y0, yN)
+    val minY = allY.minOrNull() ?: 0.0
+    val maxY = allY.maxOrNull() ?: 0.0
+    val yRange = (maxY - minY).takeIf { it != 0.0 } ?: 1.0
+    val xMax = xs.lastOrNull() ?: 1.0
+
+    Canvas(
+        modifier
+            .fillMaxWidth()
+            .height(200.dp)
+            .background(Color(0xFFEFEFEF))
+    ) {
+        val xScale = size.width / xMax.toFloat().coerceAtLeast(1f)
+        val yScale = size.height / yRange.toFloat()
+        points.forEachIndexed { index, y ->
+            val xPos = index * xScale
+            val yPos = size.height - ((y - minY).toFloat() * yScale)
+            drawCircle(Color.Blue, radius = 4.dp.toPx(), center = Offset(xPos, yPos))
+        }
+        val start = Offset(
+            0f,
+            size.height - ((y0 - minY).toFloat() * yScale)
+        )
+        val end = Offset(
+            xMax.toFloat() * xScale,
+            size.height - ((yN - minY).toFloat() * yScale)
+        )
+        drawLine(Color.Red, start, end, strokeWidth = 2.dp.toPx())
+    }
+}
+


### PR DESCRIPTION
## Summary
- Add input field and button to collect numeric values
- Plot entered values and computed linear regression line on a simple chart

## Testing
- `sh gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68bea614e93c8323ae8742f0b3936ef1